### PR TITLE
build: Add database configuration to drizzle-kit

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,12 @@
+import { env } from "@/lib/env";
+import type { Config } from "drizzle-kit";
+
+export default {
+  schema: "./src/lib/db/schema/*",
+  out: "./src/lib/db/migrations",
+  driver: "libsql",
+  dbCredentials: {
+    url: env.DATABASE_URL,
+    // authToken: env.DATABASE_AUTH_TOKEN,
+  },
+} satisfies Config;


### PR DESCRIPTION
Import the environment variable module and define a database configuration 
object in the drizzle-kit configuration file. Set the database schema path, 
output path for migrations, driver type, and database credentials using the 
environment variable for the database URL. Comment out the database 
authentication token for now. This change is necessary to ensure the 
drizzle-kit can connect to the database properly.