### PR TITLE
feat: Add Zettel extension to text editor

### DIFF
--- a/src/lib/hooks/useEditor.tsx
+++ b/src/lib/hooks/useEditor.tsx
@@ -1,19 +1,21 @@
 "use client";
 import { useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
-import { useCallback, useState } from "react";
+import { useState } from "react";
+import Zettel from "../editor/extensions/zettle/mark";
 
 export default function UseTextEditor() {
   const [editable, setEditable] = useState(true);
   const [content, setContent] = useState<string>(`<h1>Editor</h1>`);
 
-  const extensions = [StarterKit];
+  const extensions = [StarterKit, Zettel];
 
   const editor = useEditor({
     content,
     extensions,
     editable,
     autofocus: true,
+
     onCreate: () => {
       console.log("editor created");
     },
@@ -25,14 +27,9 @@ export default function UseTextEditor() {
     },
   });
 
-  const editorClear = useCallback(() => {
-    if (!editor) return;
-    console.log("clearing editor");
-    editor.commands.clearContent();
-  }, [editor]);
-
   return {
     editor,
-    editorClear,
+    setEditable,
+    setContent,
   };
 }


### PR DESCRIPTION
Added the Zettel extension to the list of extensions in the UseTextEditor component. This allows users to utilize the Zettel feature in the text editor for better organization and structure.

Removed editorClear function as it was not being utilized in the component. Replaced it with setEditable and setContent functions to adjust editable state and content of the editor.

The Zettel extension enhances the functionality of the text editor and improves the user experience.