### PR TITLE
feat(database): Add SQLite database schema

### DIFF
--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,0 +1,24 @@
+// import { sessionTable, userTable } from './schema/user';
+// import { env } from '@lib/env/server';
+import { createClient } from "@libsql/client";
+// import { DrizzleSQLiteAdapter } from '@lucia-auth/adapter-drizzle';
+import { drizzle } from "drizzle-orm/libsql";
+import { env } from "../env";
+import { folderTable, noteTable } from "./schema/note";
+import { userTable } from "./schema/user";
+
+const sqliteClient = createClient({
+  url: env.DATABASE_URL,
+  // authToken: env.DATABASE_AUTH_TOKEN,
+});
+
+export const db = drizzle(sqliteClient, {
+  schema: {
+    user: userTable,
+    // session: sessionTable,
+    note: noteTable,
+    folder: folderTable,
+  },
+});
+
+// export const dbAdapter = new DrizzleSQLiteAdapter(db, sessionTable, userTable);

--- a/src/lib/db/schema/note.ts
+++ b/src/lib/db/schema/note.ts
@@ -1,0 +1,36 @@
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { createInsertSchema, createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import { userTable } from "./user";
+
+export const noteTable = sqliteTable("note", {
+  id: text("id").notNull().primaryKey().unique(),
+  user: text("user_id")
+    .notNull()
+    .references(() => userTable.id),
+  title: text("title").notNull(),
+  description: text("description"),
+  content: text("content", {
+    mode: "text",
+  }),
+  folder: text("folder_id").references(() => folderTable.id),
+  zettels: text("zettels").default("[]"),
+  createdAt: text("created_at").notNull().default(new Date().toISOString()),
+  updateAt: text("updated_at").notNull().default(new Date().toISOString()),
+});
+
+export const insertNoteSchema = createInsertSchema(noteTable);
+export const selectNoteSchema = createSelectSchema(noteTable);
+export type Note = z.infer<typeof selectNoteSchema>;
+
+export const folderTable = sqliteTable("folder", {
+  id: text("id").notNull().primaryKey().unique(),
+  name: text("name").notNull(),
+  description: text("description"),
+  createdAt: text("created_at").notNull().default(new Date().toISOString()),
+  updateAt: text("updated_at").notNull().default(new Date().toISOString()),
+});
+
+export const insertFolderSchema = createInsertSchema(folderTable);
+export const selectFolderSchema = createSelectSchema(folderTable);
+export type Folder = z.infer<typeof selectFolderSchema>;

--- a/src/lib/db/schema/user.ts
+++ b/src/lib/db/schema/user.ts
@@ -1,0 +1,15 @@
+import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { createInsertSchema, createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+
+export const userTable = sqliteTable("user", {
+  id: text("id").notNull().primaryKey().unique(),
+  name: text("name"),
+  email: text("email").notNull(),
+  createdAt: text("created_at").notNull().default(Date.now().toLocaleString()),
+  updateAt: text("updated_at").notNull().default(Date.now().toLocaleString()),
+});
+
+export const insertUserSchema = createInsertSchema(userTable);
+export const selectUserSchema = createSelectSchema(userTable);
+export type User = z.infer<typeof selectUserSchema>;

--- a/src/lib/editor/commands.ts
+++ b/src/lib/editor/commands.ts
@@ -1,0 +1,20 @@
+import type { Editor } from "@tiptap/react";
+
+export function clearEditor(editor: Editor | null): void {
+  if (!editor) return;
+  editor.chain().focus().clearContent().run();
+  return;
+}
+
+export function saveDocument(editor: Editor | null): void {
+  if (!editor) return;
+  const content = editor.getJSON();
+  console.log(JSON.stringify(content));
+  return;
+}
+
+export function toggleZettel(editor: Editor | null): void {
+  if (!editor) return;
+  editor.chain().focus().toggleMark("zettel").run();
+  return;
+}

--- a/src/lib/editor/extensions/zettle/mark.ts
+++ b/src/lib/editor/extensions/zettle/mark.ts
@@ -1,0 +1,80 @@
+import { Mark, markInputRule, markPasteRule } from "@tiptap/react";
+
+const inputRegex = /(\[\[([^\]]+)\]\])/g;
+
+type ZettelOptions = {
+  HTMLAttributes: Record<string, string>;
+};
+
+declare module "@tiptap/react" {
+  interface Commands<ReturnType> {
+    zettel: {
+      setZettel: () => ReturnType;
+      toggleZettel: () => ReturnType;
+      unsetZettel: () => ReturnType;
+    };
+  }
+}
+
+const ZettelExtension = Mark.create<ZettelOptions>({
+  name: "zettel",
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
+  addInputRules() {
+    return [
+      markInputRule({
+        find: inputRegex,
+        type: this.type,
+      }),
+    ];
+  },
+
+  addPasteRules() {
+    return [
+      markPasteRule({
+        find: inputRegex,
+        type: this.type,
+      }),
+    ];
+  },
+
+  addCommands() {
+    return {
+      setZettel:
+        () =>
+          ({ commands }) => {
+            return commands.setMark("zettel");
+          },
+      toggleZettel:
+        () =>
+          ({ commands }) => {
+            return commands.toggleMark("zettel");
+          },
+      unsetZettel:
+        () =>
+          ({ commands }) => {
+            return commands.unsetMark("zettel");
+          },
+    };
+  },
+
+  renderHTML({ HTMLAttributes, mark }) {
+    return ["a", { ...HTMLAttributes, "data-type": "zettel" }, 0];
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'a[data-type="zettel"]',
+        mark: this.name,
+      },
+    ];
+  },
+});
+
+export default ZettelExtension;

--- a/src/lib/editor/helpers.ts
+++ b/src/lib/editor/helpers.ts
@@ -1,0 +1,37 @@
+import { JSONContent } from "@tiptap/react";
+
+export function getZettelLinks(
+  content: JSONContent[] | undefined,
+  links: string[] = [],
+): string[] {
+  if (!content) return [];
+  content.forEach((node) => {
+    if (node.type === "text" && node.text && node.marks) {
+      // Check if the text node has a zettel-link mark
+      const hasZettelLink = node.marks.some((mark) => mark.type === "zettel");
+      if (hasZettelLink) {
+        // If it does, add the text to the links array
+        links.push(node.text);
+      }
+    } else if (node.content) {
+      // If the node has more content, recursively process each child node
+      getZettelLinks(node.content, links);
+    }
+  });
+
+  return links;
+}
+
+export function getTitle(content: JSONContent[] | undefined): string | null {
+  if (!content) return null;
+  for (const node of content) {
+    if (node.type === "heading" && node.attrs && node.attrs.level === 1) {
+      // Assuming the heading contains text in its content array
+      const headingText = node.content
+        ?.map((textNode) => textNode.text)
+        .join("");
+      return headingText || null;
+    }
+  }
+  return null; // Return null if no level 1 heading is found
+}


### PR DESCRIPTION
Added SQLite database schema for users, notes, and folders using drizzle-orm and drizzle-zod. Includes table definitions, insert schemas, and select schemas for user, note, and folder entities. ForeignKey constraints are set for relationships between entities where applicable.