### PR TITLE
style: Add placeholder text for empty tiptap editor

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -95,6 +95,14 @@
   outline: none;
 }
 
+.tiptap .is-empty::before {
+  content: attr(data-placeholder);
+  float: left;
+  color: #ced4da;
+  pointer-events: none;
+  height: 0;
+}
+
 .ProseMirror * {
   @apply my-0 leading-none
 }


### PR DESCRIPTION
Added CSS to display a placeholder text for empty tiptap editor elements. This provides a visual cue for users on what to input in the editor when it's empty.