### PR TITLE
feat: Add trashed field to noteTable

### DIFF
--- a/src/lib/db/schema/note.ts
+++ b/src/lib/db/schema/note.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 import { z } from "zod";
 import { userTable } from "./user";
@@ -15,6 +15,9 @@ export const noteTable = sqliteTable("note", {
   }),
   folder: text("folder_id").references(() => folderTable.id),
   zettels: text("zettels").default("[]"),
+  trashed: integer("trashed", {
+    mode: "boolean",
+  }).default(false),
   createdAt: text("created_at").notNull().default(new Date().toISOString()),
   updateAt: text("updated_at").notNull().default(new Date().toISOString()),
 });


### PR DESCRIPTION
Added the `trashed` field as an integer with boolean mode to the `noteTable` in order to keep track of whether a note has been trashed or not. The default value is set to `false` for new notes. This change enhances the functionality of the table by adding a new attribute to handle note trashing.