### PR TITLE
refactor: Filter out trashed notes in Folder component

### DIFF
--- a/src/components/app/menu/files/note.tsx
+++ b/src/components/app/menu/files/note.tsx
@@ -4,28 +4,29 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import { deleteNote } from "@/lib/actions/editor";
+import { deleteNote, trashNote } from "@/lib/actions/editor";
 import type { Note } from "@/lib/db/schema/note";
 import { FileText } from "lucide-react";
 
 type Props = {
   note: Note;
 };
-export default async function Note({ note }: Props) {
+export default function Note({ note }: Props) {
   const dn = deleteNote.bind(null, { id: note.id });
+  const tn = trashNote.bind(null, { id: note.id });
   return (
     <ContextMenu>
       <ContextMenuTrigger>
-        <li key={note.id} className="flex items-center gap-1 w-full">
+        <div key={note.id} className="flex items-center gap-1 w-full">
           <FileText size={16} />
           <a className="w-full line-clamp-1" href={`/app/editor/${note.id}`}>
             {note.title}
           </a>
-        </li>
+        </div>
       </ContextMenuTrigger>
       <ContextMenuContent>
         <ContextMenuItem>
-          <form action={dn}>
+          <form action={note.trashed ? dn : tn}>
             <button type="submit">delete</button>
           </form>
         </ContextMenuItem>

--- a/src/components/app/menu/files/trash.tsx
+++ b/src/components/app/menu/files/trash.tsx
@@ -12,38 +12,44 @@ import {
   ContextMenuShortcut,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import type { Folder, Note as NoteType } from "@/lib/db/schema/note";
-import { FolderIcon, FolderOpenIcon, Trash } from "lucide-react";
+import type { Note as NoteType } from "@/lib/db/schema/note";
+import { Trash2, TrashIcon } from "lucide-react";
 import { useState } from "react";
 import Note from "./note";
 
 type Props = {
-  folder: Folder;
   notes: NoteType[];
 };
 
-export default function Folder({ folder, notes }: Props) {
+export default function Trash({ notes }: Props) {
   const [open, setOpen] = useState(false);
-  const folderNotes = notes.filter(
-    (note) => note.folder === folder.id && !note.trashed,
-  );
-
+  const trashedNotes = notes.filter((note) => note.trashed);
   return (
     <ContextMenu>
       <ContextMenuTrigger>
-        <Collapsible open={open} onOpenChange={setOpen} key={folder.id}>
+        <Collapsible open={open} onOpenChange={setOpen}>
           <CollapsibleTrigger asChild>
             <div className="w-full cursor-pointer flex items-center gap-1">
-              {open ? <FolderOpenIcon size={16} /> : <FolderIcon size={16} />}
-              <span className="line-clamp-1">{folder.name}</span>
+              {trashedNotes.length > 0 ? (
+                <Trash2 size={16} />
+              ) : (
+                <TrashIcon size={16} />
+              )}
+              <span className="line-clamp-1">Trash</span>
             </div>
           </CollapsibleTrigger>
           <CollapsibleContent asChild>
             <ul className="pl-5">
-              {folderNotes.length > 0 ? (
-                folderNotes.map((note) => <Note key={note.id} note={note} />)
+              {trashedNotes.length > 0 ? (
+                trashedNotes.map((note) => {
+                  return (
+                    <li key={note.id}>
+                      <Note note={note} />
+                    </li>
+                  );
+                })
               ) : (
-                <li className="text-muted-foreground text-xs">Empty folder</li>
+                <li>No trashed notes</li>
               )}
             </ul>
           </CollapsibleContent>
@@ -53,13 +59,13 @@ export default function Folder({ folder, notes }: Props) {
         <ContextMenuItem>
           Delete
           <ContextMenuShortcut>
-            <Trash size={16} />
+            <TrashIcon size={16} />
           </ContextMenuShortcut>
         </ContextMenuItem>
         <ContextMenuItem>
           Rename
           <ContextMenuShortcut>
-            <Trash size={16} />
+            <TrashIcon size={16} />
           </ContextMenuShortcut>
         </ContextMenuItem>
       </ContextMenuContent>


### PR DESCRIPTION
In the Folder component, filter out trashed notes from the list of folderNotes by checking the note.trashed property.

feat: Implement trashNote action in Note component

Add the trashNote action to handle trashing notes in the Note component. Modify the form action based on whether the note is already trashed or not.

feat: Add Trash component to display trashed notes

Create the Trash component to display trashed notes. Filter out trashed notes and render them in a collapsible list. Include options to delete and rename trashed notes.