### PR TITLE
refactor(ui): Update icons and navigation layout in Nav component

### DIFF
--- a/src/components/app/menu/files/trash.tsx
+++ b/src/components/app/menu/files/trash.tsx
@@ -49,7 +49,9 @@ export default function Trash({ notes }: Props) {
                   );
                 })
               ) : (
-                <li>No trashed notes</li>
+                <li className="text-muted-foreground text-xs">
+                  No trashed notes
+                </li>
               )}
             </ul>
           </CollapsibleContent>

--- a/src/components/app/menu/index.tsx
+++ b/src/components/app/menu/index.tsx
@@ -11,14 +11,11 @@ export default async function Menu() {
 
   return (
     <section className="col-span-2 grid grid-cols-4 border-r-[1px] border-muted-foreground/20">
-      <div className="border-r-[1px] pt-4 border-muted-foreground/20 px-4 flex flex-col items-center">
+      <div className="border-r-[1px] py-4 border-muted-foreground/20 px-4 flex flex-col items-center">
         <Nav />
       </div>
       <div className="col-span-3 px-4 text-sm pt-4">
         <ul className="flex flex-col gap-1">
-          <li>
-            <a href="/app/editor">Go To Editor</a>
-          </li>
           <li>
             <Trash notes={notes} />
           </li>

--- a/src/components/app/menu/nav/index.tsx
+++ b/src/components/app/menu/nav/index.tsx
@@ -1,21 +1,25 @@
 import { Button } from "@/components/ui/button";
-import { Archive, Settings, Trash2, User } from "lucide-react";
+import { Archive, Pen, Settings, User } from "lucide-react";
 
 export default function Nav() {
   return (
-    <nav className="space-y-2 flex flex-col items-center">
-      <Button size="icon">
-        <Settings size={16} />
-      </Button>
+    <div className="flex items-center flex-col h-full justify-between">
+      <nav className="space-y-2 flex flex-col items-center">
+        <Button asChild size="icon">
+          <a href="/app/editor">
+            <Pen size={16} />
+          </a>
+        </Button>
+        <Button size="icon">
+          <Archive size={16} />
+        </Button>
+        <Button size="icon">
+          <Settings size={16} />
+        </Button>
+      </nav>
       <Button size="icon">
         <User size={16} />
       </Button>
-      <Button size="icon">
-        <Archive size={16} />
-      </Button>
-      <Button size="icon">
-        <Trash2 size={16} />
-      </Button>
-    </nav>
+    </div>
   );
 }


### PR DESCRIPTION
- Updated the icon imported from lucide-react to be a Pen icon instead of Trash2
- Adjusted the structure of the navigation in the Nav component to include the Pen icon with a link to /app/editor
- Removed the Trash2 icon from the Nav component
- Made the Nav component layout more organized with a flex column structure

This commit improves the visual representation of the navigation elements in the UI by updating icons and restructuring the layout for better user experience.