### PR TITLE
refactor: Remove TextEditor component from App and replace with simple paragraph element

### DIFF
--- a/src/app/(pages)/app/page.tsx
+++ b/src/app/(pages)/app/page.tsx
@@ -1,9 +1,7 @@
-import TextEditor from "@/components/app/editor";
-
 export default function App() {
   return (
     <section className="col-span-9">
-      <TextEditor />
+      <p>App</p>
     </section>
   );
 }


### PR DESCRIPTION
This change removes the TextEditor component from the App component and replaces it with a simple paragraph element. This was done to simplify the App component and remove unnecessary complexity.